### PR TITLE
Refactor/dict implementation

### DIFF
--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -106,18 +106,38 @@ mutable struct Node{D,L,K,T<:KTuple{K}}
     depth::Int
 end
 
+function Node(T::Type{S}, l, i) where {S <: KTuple}
+    lt = Tuple(l)
+    it = Tuple(i)
+    N  = length(lt)
+
+    return Node(0,
+                MMatrix{N, 2}(zeros(Int, N,2)),
+                getzero(T),
+                SVector{N}(Y.(lt,it)),
+                getzero(T),
+                lt, it, sum(l) - N + 1)
+end
+
+function Node(parent, children, α, l::NTuple{N,Int}, i::NTuple{N,Int}, depth) where N
+    x  = SVector{N,Float64}(Y.(l, i))
+    fx = getzero(α)
+    n  = Node(typeof(α), l,i)
+    n.parent = parent
+    n.α      = α
+    n.fx     = fx
+    return n
+end
+
+Node(T::KTuple, l, i) = Node(typeof(T), l, i)
+Node(l, i)            = Node(Tuple{Float64}, l, i)
+
 getx(n::Node) = n.x
 
 getzero(t::T) where {T <: KTuple}                   = T(zero(tv) for tv in t)
 getzero(TT::Type{K}) where {N,T, K <: KTuple{N,T}}  = TT(zero(T) for i in 1:N)
 getzero(t::Vector)                                  = Tuple(zeros(size(t)))
 getzero(t::Number)                                  = (zero(t),)
-
-function Node(parent, children, α, l::NTuple{N,Int}, i::NTuple{N,Int}, depth) where N
-    x  = SVector{N,Float64}(Y.(l, i))
-    fx = getzero(α)
-    return Node(parent, children, α, x, fx, l, i, depth)
-end
 
 function leftchild(idx::Int, p::Node{D,L,K}, d) where {D, L, K}
     # Compute child along the dth dimension

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,21 +216,21 @@ end
     end
 
     @testset "Node 1D" begin
-        import AdaptiveSparseGrids: Node, getx, ϕ
+        import AdaptiveSparseGrids: Node, getx, ϕ, makeleftchild, makerightchild
         n = Node(1,1)
         @test ϕ(n, (0.0,), 1) == 1.0
         @test ϕ(n, (0.5,), 1) == 1.0
         @test ϕ(n, (1.0,), 1) == 1.0
 
         # Check the children
-        lc = leftchild(1, n, 1)
+        lc = makeleftchild(n, 1)
         @test getx(lc) == @SVector [0.0]
         @test ϕ(lc, 0.0, 1) == 1.0
         @test ϕ(lc, 0, 1)   == 1.0
         @test ϕ(lc, 0.5, 1) == 0.0
         @test ϕ(lc, 0.25, 1) == 0.5
 
-        rc = rightchild(1, n, 1)
+        rc = makerightchild(n, 1)
         @test getx(rc) == @SVector [1.0]
         @test ϕ(rc, 1.0, 1) == 1.0
         @test ϕ(rc, 1, 1)   == 1.0
@@ -251,7 +251,7 @@ end
     end
 
     @testset "Node 2D" begin
-        import AdaptiveSparseGrids: Node, getx, ϕ
+        import AdaptiveSparseGrids: Node, getx, ϕ, m, Y
         for l1 in 3:5, l2 in 3:5, i1 in 1:2:m(l1), i2 in 1:2:m(l2)
             n = Node((l1,l2), (i1, i2))
 
@@ -342,7 +342,7 @@ end
     h(x...)  = h(x)
 
     f = AdaptiveSparseGrid(h, [0.0, 0.0], [2 * pi, 2 * pi],
-                           tol=1e-6, max_depth = 20)
+                           tol=1e-6, max_depth = 20, train=false)
 
     for x in LinRange(0,2*pi,100), y in LinRange(0,2*pi,100)
         @test f((x,y)) ≈ h(x,y) atol = 1e-6
@@ -358,7 +358,7 @@ end
     end
 
     # Check that the max depth parameter works
-    @test mapreduce(x -> x.depth, max, nodes(f)) <= f.max_depth
+    @test mapreduce(x -> x.depth, max, values(nodes(f))) <= f.max_depth
 
     # Now a version from R^2 →  R^2
     h((x,y)) = (a = sin(x) * cos(y), b = x^2 + y^2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,7 +342,7 @@ end
     h(x...)  = h(x)
 
     f = AdaptiveSparseGrid(h, [0.0, 0.0], [2 * pi, 2 * pi],
-                           tol=1e-6, max_depth = 20, train=false)
+                           tol=1e-6, max_depth = 20)
 
     for x in LinRange(0,2*pi,100), y in LinRange(0,2*pi,100)
         @test f((x,y)) ≈ h(x,y) atol = 1e-6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ using QuadGK
         @test ϕ(0.25) == 0.75
         @test ϕ(0.75) == 0.25
 
-        for x in LinRange(0, 1, 100)
+        for x in LinRange(0, 1, 5)
             # Test Symmetry
             @test ϕ(x) == ϕ(-x)
 
@@ -92,7 +92,7 @@ using QuadGK
     end
 
     @testset "Dϕ: Derivatives" begin
-        for x in LinRange(-1, 1, 101)
+        for x in LinRange(-1, 1, 5)
             @test Dϕ(x) == ForwardDiff.derivative(ϕ, x)
         end
     end
@@ -217,11 +217,7 @@ end
 
     @testset "Node 1D" begin
         import AdaptiveSparseGrids: Node, getx, ϕ
-        node(l, i) = Node(0,
-                          @MMatrix(zeros(Int, 1,2)),
-                          (a = 0.0, b = 0.0),
-                          (l,), (i,), 1)
-        n = node(1,1)
+        n = Node(1,1)
         @test ϕ(n, (0.0,), 1) == 1.0
         @test ϕ(n, (0.5,), 1) == 1.0
         @test ϕ(n, (1.0,), 1) == 1.0
@@ -242,7 +238,7 @@ end
         @test ϕ(rc, 0.75, 1) == 0.5
 
         for l in 3:10, j in 1:2:m(l)
-            n = node(l, j)
+            n = Node(l, j)
             @test getx(n) == @SVector [Y(l, j)]
             @test ϕ(n, getx(n), 1) == 1.0
             @test ϕ(n, Y(leftchild(l,j)...), 1)  == 0.5
@@ -256,13 +252,8 @@ end
 
     @testset "Node 2D" begin
         import AdaptiveSparseGrids: Node, getx, ϕ
-        node(l, i) = Node(0,
-                          @MMatrix(zeros(Int, 2 ,2)),
-                          (a = 0.0, b = 0.0),
-                          l, i, 1)
-
         for l1 in 3:5, l2 in 3:5, i1 in 1:2:m(l1), i2 in 1:2:m(l2)
-            n = node((l1,l2), (i1, i2))
+            n = Node((l1,l2), (i1, i2))
 
             # Check that we're linearly interpolating to the corners
             for d1 in -1:1, d2 in -1:1
@@ -365,6 +356,9 @@ end
         @test f((x,2)) == f(x, 2.0)
         @test f((2,x)) == f(2.0, x)
     end
+
+    # Check that the max depth parameter works
+    @test mapreduce(x -> x.depth, max, nodes(f)) <= f.max_depth
 
     # Now a version from R^2 →  R^2
     h((x,y)) = (a = sin(x) * cos(y), b = x^2 + y^2)


### PR DESCRIPTION
Refactor of internals to use a dictionary implementation of node lookups, and recursively add all parents before adding children to the function approximation.  

It also fixes the notion of node depth so that the max_depth parameter controls the maximum depth in _each_ dimension, rather than the maximum depth of the tree.  This gives much more accurate results, and corresponds better to what the user will expect.