### PR TITLE
Remove Allocations

### DIFF
--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -584,7 +584,7 @@ function procreate!(fun; tol = 1e-3)
             #
             # Note: We insist on refining up to at least the 3rd layer to make
             # sure that we don't stop prematurely
-            node.depth > 3 && err(node) < tol   && continue
+            node.depth > 6 && err(node) < tol   && continue
 
 
             # Add in the children -- this should be a separate function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -370,7 +370,7 @@ end
     end
 
     # Check that the max depth parameter works
-    @test mapreduce(x -> x.depth, max, values(nodes(f))) <= f.max_depth
+    @test mapreduce(x -> x.depth, max, values(nodes(f))) <= AdaptiveSparseGrids.max_depth(f)
     
     # Check that Tuple Constructors Work
     f = AdaptiveSparseGrid(h, (0.0, 0.0), (2 * pi, 2 * pi),


### PR DESCRIPTION
Rework the recursive evaluation algorithm to use static vectors instead of allocating a work buffer.  Code is easier to reason about, and evaluating the interpolant no longer allocates memory!  

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>