### PR TITLE
Perf: 7-21x serial eval, bulk parallel path (+ CI fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,39 +16,30 @@ jobs:
         arch:
           - x64
           - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
+      - uses: julia-actions/cache@v2
       - run: |
           julia --project=docs -e '
             using Pkg
@@ -57,7 +48,7 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Documenter: doctest
-            using AdaptiveSparseGrids 
+            using AdaptiveSparseGrids
             doctest(AdaptiveSparseGrids)'
       - run: julia --project=docs docs/make.jl
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          # Exercise Threads.@threads in bulk eval paths. Without this,
+          # CI runs at JULIA_NUM_THREADS=1 and the parallel dispatch
+          # logic (race conditions, thread-local scratch isolation) is
+          # never exercised on CI. Deterministic chunk-boundary coverage
+          # is provided separately via _bulk_evaluate_batched!'s internal
+          # `nchunks` / `threaded` kwargs.
+          JULIA_NUM_THREADS: auto
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ fun(x, 1)       # returns value of fun[1] at x (if f: R^n -> R^m with m > 1)
 length(fun)
 ```
 
+## Evaluating many points at once
+
+If you have a cloud of points to evaluate, **always use the bulk form
+`evaluate!(ys, fun, xs)`** instead of looping `fun(x)` yourself. For
+scalar-codomain grids it runs a single batch-coherent traversal of the
+tree across the whole point cloud in parallel, which can be **one to two
+orders of magnitude faster** than per-point evaluation — the tree is
+walked once and each node contributes to every point that lands in its
+support.
+
+```julia
+using AdaptiveSparseGrids
+using StaticArrays
+
+fun = AdaptiveSparseGrid(x -> exp(-sum(abs2, x)), fill(-1.0, 4), fill(1.0, 4);
+                         tol = 1e-3, max_depth = 10)
+
+# Many query points
+xs = [SVector{4,Float64}(2 .* rand(4) .- 1) for _ in 1:100_000]
+ys = similar(xs, Float64)
+
+AdaptiveSparseGrids.evaluate!(ys, fun, xs)   # parallel, batch-coherent
+```
+
+Run Julia with `-t auto` (or set `JULIA_NUM_THREADS`) to get the
+parallel speedup. The bulk path falls back to per-point parallel
+evaluation when the codomain has more than one component.
+
 ## Functions can return named arguments
 The return type of the functions can be named tuples.  You can reference the fieldnames later when accessing the results!
 

--- a/bench/Project.toml
+++ b/bench/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+AdaptiveSparseGrids = "676d8d29-539e-4f06-b848-7dd647dd5291"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/bench/benchmarks.jl
+++ b/bench/benchmarks.jl
@@ -1,0 +1,197 @@
+#=
+Performance benchmarks for AdaptiveSparseGrids.jl.
+
+Measures:
+  1. Grid construction (`AdaptiveSparseGrid(f, lb, ub; tol, max_depth)`)
+     across varying dimensions and tolerances.
+  2. Single-point evaluation of a trained interpolant (latency + allocations).
+  3. Bulk evaluation on a cloud of points (throughput).
+  4. Integration (`AdaptiveIntegral`).
+
+Run with:
+
+    julia --project=bench -t auto bench/benchmarks.jl
+=#
+
+using AdaptiveSparseGrids
+using BenchmarkTools
+using Printf
+using Random
+using StaticArrays
+using Statistics
+
+const SEED = 0xB0BACAFE
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+
+# Smooth-ish target functions with tunable dimensionality. They stay cheap
+# so we time the grid machinery, not the integrand.
+gauss(x)  = exp(-sum(abs2, x) / length(x))
+runge(x)  = 1.0 / (1.0 + sum(abs2, x))
+oscil(x)  = sum(sin(2π * xi) for xi in x) / length(x)
+
+const FUNCS = ((:gauss, gauss), (:runge, runge), (:oscil, oscil))
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+row(cols...) = join(cols, " | ")
+
+function header(title)
+    println()
+    println("=" ^ 78)
+    println(title)
+    println("=" ^ 78)
+end
+
+function build(f, N; tol = 1e-3, max_depth = 10)
+    lb = fill(-1.0, N)
+    ub = fill( 1.0,  N)
+    return AdaptiveSparseGrid(f, lb, ub; tol = tol, max_depth = max_depth)
+end
+
+function random_points(N, M; seed = SEED)
+    rng = MersenneTwister(seed)
+    return [SVector{N,Float64}(2 .* rand(rng, N) .- 1) for _ in 1:M]
+end
+
+# ---------------------------------------------------------------------------
+# 1. Construction
+# ---------------------------------------------------------------------------
+
+function bench_construction()
+    header("Construction: time / allocations / #nodes")
+    println(row(lpad("function", 8), lpad("N", 3), lpad("tol", 8),
+                lpad("depth", 5), lpad("nodes", 8), lpad("time (ms)", 12),
+                lpad("alloc (MiB)", 12)))
+    println("-" ^ 78)
+
+    # (N, tol, max_depth) configurations. Kept modest so the full suite
+    # completes in a couple of minutes.
+    configs = [
+        (2,  1e-4, 10),
+        (3,  1e-3, 10),
+        (4,  1e-2,  9),
+        (5,  1e-2,  8),
+    ]
+
+    results = Dict{Tuple{Symbol,Int},Any}()
+    for (fname, f) in FUNCS
+        for (N, tol, depth) in configs
+            b = @benchmark build($f, $N; tol = $tol, max_depth = $depth) samples=2 evals=1 seconds=20
+            fun = build(f, N; tol = tol, max_depth = depth)
+            results[(fname, N)] = fun
+            println(row(
+                lpad(string(fname), 8),
+                lpad(N, 3),
+                lpad(@sprintf("%.0e", tol), 8),
+                lpad(depth, 5),
+                lpad(length(fun), 8),
+                lpad(@sprintf("%.2f", minimum(b.times) / 1e6), 12),
+                lpad(@sprintf("%.2f", b.memory / 2^20), 12),
+            ))
+        end
+    end
+    return results
+end
+
+# ---------------------------------------------------------------------------
+# 2. Single-point evaluation (latency)
+# ---------------------------------------------------------------------------
+
+function bench_single_eval(funs)
+    header("Single-point eval: time per call / allocations")
+    println(row(lpad("function", 8), lpad("N", 3), lpad("nodes", 8),
+                lpad("ns/call", 10), lpad("allocs", 8)))
+    println("-" ^ 78)
+
+    for ((fname, N), fun) in sort(collect(funs); by = first)
+        pts = random_points(N, 64)
+        b = @benchmark for x in $pts; $fun(x); end samples=50 evals=1 seconds=10
+        per_call_ns = minimum(b.times) / length(pts)
+        println(row(
+            lpad(string(fname), 8),
+            lpad(N, 3),
+            lpad(length(fun), 8),
+            lpad(@sprintf("%.1f", per_call_ns), 10),
+            lpad(b.allocs, 8),
+        ))
+    end
+end
+
+# ---------------------------------------------------------------------------
+# 3. Bulk evaluation (throughput, serial)
+# ---------------------------------------------------------------------------
+
+function bench_bulk_eval(funs; npts = 50_000)
+    header("Bulk serial eval: throughput on $npts random points")
+    println(row(lpad("function", 8), lpad("N", 3), lpad("nodes", 8),
+                lpad("total (ms)", 12), lpad("Mcalls/s", 10)))
+    println("-" ^ 78)
+
+    for ((fname, N), fun) in sort(collect(funs); by = first)
+        pts = random_points(N, npts)
+        # Single warm-up + timed pass. Use @elapsed for fewer repetitions
+        # since the work dominates.
+        # Warm up
+        let s = 0.0
+            for x in pts; s += fun(x)[1]; end
+        end
+        t = @elapsed for x in pts; fun(x); end
+        println(row(
+            lpad(string(fname), 8),
+            lpad(N, 3),
+            lpad(length(fun), 8),
+            lpad(@sprintf("%.2f", t * 1e3), 12),
+            lpad(@sprintf("%.2f", npts / t / 1e6), 10),
+        ))
+    end
+end
+
+# ---------------------------------------------------------------------------
+# 4. Integration
+# ---------------------------------------------------------------------------
+
+function bench_integration()
+    header("AdaptiveIntegral: construction + call")
+    println(row(lpad("N", 3), lpad("tol", 8), lpad("depth", 5),
+                lpad("build (ms)", 12), lpad("call (µs)", 10)))
+    println("-" ^ 78)
+
+    for N in 2:3
+        lb = fill(-1.0, N); ub = fill(1.0, N)
+        b_build = @benchmark AdaptiveIntegral(gauss, $lb, $ub, 1;
+                                              tol = 1e-2, max_depth = 9) samples=2 evals=1 seconds=15
+        fun = AdaptiveIntegral(gauss, lb, ub, 1; tol = 1e-2, max_depth = 9)
+        xs  = random_points(N - 1, 128)
+        b_call = @benchmark for x in $xs; $fun(x); end samples=10 evals=1 seconds=5
+        println(row(
+            lpad(N, 3),
+            lpad(@sprintf("%.0e", 1e-3), 8),
+            lpad(10, 5),
+            lpad(@sprintf("%.2f", minimum(b_build.times) / 1e6), 12),
+            lpad(@sprintf("%.2f", (minimum(b_call.times) / length(xs)) / 1e3), 10),
+        ))
+    end
+end
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+function main()
+    println("AdaptiveSparseGrids.jl benchmark")
+    println("Threads: ", Threads.nthreads())
+    println("Julia  : ", VERSION)
+
+    funs = bench_construction()
+    bench_single_eval(funs)
+    bench_bulk_eval(funs)
+    bench_integration()
+    println()
+end
+
+main()

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -106,30 +106,30 @@ end
 
 # Count node visits for one call, using the same traversal logic as
 # evaluate_recursive. Only used for the "visits/call" column — not the hot path.
-using AdaptiveSparseGrids: Index, childsplit, leftchild, rightchild, base, scale, dims, ϕ
+using AdaptiveSparseGrids: childsplit, scale, ϕ
 
 function count_visits(fun, x)
     xs = scale(fun, x)
     c = Ref(0)
-    _visit!(c, fun, base(fun), 1, xs)
+    _visit!(c, fun._eval, fun._eval[1], 1, xs)
     return c[]
 end
 
-function _visit!(c, fun, idx, dimshift, x)
+function _visit!(c, arr, node, dimshift, x)
     c[] += 1
-    node = fun.nodes[idx]
+    D = length(node.l)
     u = 1.0
-    for d in 1:length(node.l); u *= ϕ(node, x, d); end
+    for d in 1:D; u *= ϕ(node, x, d); end
     u > 0 || return
-    for d in 1:length(node.l)
+    for d in 1:D
         kd = childsplit(node, x, d)
         if kd > 0
-            child = kd == 1 ? leftchild(idx, d) : rightchild(idx, d)
-            if haskey(fun.nodes, child)
-                _visit!(c, fun, child, d, x)
+            cid = kd == 1 ? node.left[d] : node.right[d]
+            if cid != Int32(0)
+                _visit!(c, arr, arr[cid], d, x)
             end
         end
-        if idx[1][d] > 1; break; end
+        node.l[d] > 1 && break
     end
     return
 end

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -3,11 +3,13 @@ Small, reproducible benchmark used to track per-commit performance changes.
 Designed to be fast (~30s total) and deterministic so output can be pasted
 directly into commit messages.
 
-Reports: single-point eval time, bulk-eval throughput, nodes visited per call.
+Reports: single-point eval time, bulk serial + parallel throughput,
+nodes visited per call.
 
-Run:  julia --project=bench -t 1 bench/compare.jl
-(single thread on purpose — traversal is serial today, so threads just
- add noise. `construction` uses threads internally via Threads.@threads.)
+Run:  julia --project=bench -t auto bench/compare.jl
+(The bulk parallel column is only reported when nthreads > 1. Run with
+ -t 1 if you only want serial numbers. Single-point eval and bulk
+ serial throughput are unaffected by thread count.)
 =#
 
 using AdaptiveSparseGrids

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -1,0 +1,115 @@
+#=
+Small, reproducible benchmark used to track per-commit performance changes.
+Designed to be fast (~30s total) and deterministic so output can be pasted
+directly into commit messages.
+
+Reports: single-point eval time, bulk-eval throughput, nodes visited per call.
+
+Run:  julia --project=bench -t 1 bench/compare.jl
+(single thread on purpose — traversal is serial today, so threads just
+ add noise. `construction` uses threads internally via Threads.@threads.)
+=#
+
+using AdaptiveSparseGrids
+using BenchmarkTools
+using Printf
+using Random
+using StaticArrays
+
+const SEED = 0xB0BACAFE
+
+gauss(x) = exp(-sum(abs2, x) / length(x))
+runge(x) = 1.0 / (1.0 + sum(abs2, x))
+
+# Fixed workloads. Kept small enough for fast iteration.
+const WORKLOADS = [
+    (:gauss_3d, gauss, 3, 1e-3, 10),
+    (:gauss_4d, gauss, 4, 1e-2,  9),
+    (:runge_4d, runge, 4, 1e-2,  9),
+    (:gauss_5d, gauss, 5, 1e-2,  8),
+]
+
+function build(f, N, tol, depth)
+    lb = fill(-1.0, N); ub = fill(1.0, N)
+    return AdaptiveSparseGrid(f, lb, ub; tol = tol, max_depth = depth)
+end
+
+function random_points(N, M; seed = SEED)
+    rng = MersenneTwister(seed)
+    return [SVector{N,Float64}(2 .* rand(rng, N) .- 1) for _ in 1:M]
+end
+
+function fmt_ns(ns)
+    ns < 1e3   && return @sprintf("%6.1f ns", ns)
+    ns < 1e6   && return @sprintf("%6.2f µs", ns / 1e3)
+    return @sprintf("%6.2f ms", ns / 1e6)
+end
+
+function main()
+    println("AdaptiveSparseGrids.jl — compare")
+    println("threads=", Threads.nthreads(), "  julia=", VERSION, "  bench=", basename(@__FILE__))
+    println()
+    header = @sprintf("%-12s | %6s | %8s | %11s | %10s | %10s",
+                      "workload", "N", "nodes", "eval (1 pt)", "bulk Mcalls/s", "visits/call")
+    println(header)
+    println("-" ^ length(header))
+
+    for (name, f, N, tol, depth) in WORKLOADS
+        fun = build(f, N, tol, depth)
+        pts = random_points(N, 5_000)
+
+        # Warmup
+        for x in pts[1:100]; fun(x); end
+
+        # Single-point eval (1 of the 5_000 points, median over many reps)
+        b = @benchmark $fun($(pts[1])) samples=200 evals=5 seconds=2
+
+        # Bulk throughput: time 5000 calls once (after warmup).
+        # Report median of 3 runs to smooth jitter.
+        ts = Float64[]
+        for _ in 1:3
+            t = @elapsed for x in pts; fun(x); end
+            push!(ts, t)
+        end
+        sort!(ts); tmed = ts[2]
+        mcalls = length(pts) / tmed / 1e6
+
+        visits = count_visits(fun, pts[1])
+
+        println(@sprintf("%-12s | %6d | %8d | %11s | %13.2f | %10d",
+                          string(name), N, length(fun), fmt_ns(minimum(b.times)),
+                          mcalls, visits))
+    end
+end
+
+# Count node visits for one call, using the same traversal logic as
+# evaluate_recursive. Only used for the "visits/call" column — not the hot path.
+using AdaptiveSparseGrids: Index, childsplit, leftchild, rightchild, base, scale, dims, ϕ
+
+function count_visits(fun, x)
+    xs = scale(fun, x)
+    c = Ref(0)
+    _visit!(c, fun, base(fun), 1, xs)
+    return c[]
+end
+
+function _visit!(c, fun, idx, dimshift, x)
+    c[] += 1
+    node = fun.nodes[idx]
+    u = 1.0
+    for d in 1:length(node.l); u *= ϕ(node, x, d); end
+    u > 0 || return
+    for d in 1:length(node.l)
+        kd = childsplit(node, x, d)
+        if kd > 0
+            child = kd == 1 ? leftchild(idx, d) : rightchild(idx, d)
+            if haskey(fun.nodes, child)
+                _visit!(c, fun, child, d, x)
+            end
+        end
+        if idx[1][d] > 1; break; end
+    end
+    return
+end
+
+main()

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -49,8 +49,14 @@ function main()
     println("AdaptiveSparseGrids.jl — compare")
     println("threads=", Threads.nthreads(), "  julia=", VERSION, "  bench=", basename(@__FILE__))
     println()
-    header = @sprintf("%-12s | %6s | %8s | %11s | %10s | %10s",
-                      "workload", "N", "nodes", "eval (1 pt)", "bulk Mcalls/s", "visits/call")
+    nthreads = Threads.nthreads()
+    header = nthreads > 1 ?
+        @sprintf("%-12s | %6s | %8s | %11s | %10s | %12s | %8s",
+                 "workload", "N", "nodes", "eval (1 pt)", "bulk ser.",
+                 "bulk par.", "visits") :
+        @sprintf("%-12s | %6s | %8s | %11s | %10s | %8s",
+                 "workload", "N", "nodes", "eval (1 pt)", "bulk ser.",
+                 "visits")
     println(header)
     println("-" ^ length(header))
 
@@ -64,21 +70,37 @@ function main()
         # Single-point eval (1 of the 5_000 points, median over many reps)
         b = @benchmark $fun($(pts[1])) samples=200 evals=5 seconds=2
 
-        # Bulk throughput: time 5000 calls once (after warmup).
-        # Report median of 3 runs to smooth jitter.
+        # Bulk serial throughput (Mcalls/s)
         ts = Float64[]
         for _ in 1:3
             t = @elapsed for x in pts; fun(x); end
             push!(ts, t)
         end
-        sort!(ts); tmed = ts[2]
-        mcalls = length(pts) / tmed / 1e6
+        sort!(ts); tser = ts[2]
+        mser = length(pts) / tser / 1e6
 
         visits = count_visits(fun, pts[1])
 
-        println(@sprintf("%-12s | %6d | %8d | %11s | %13.2f | %10d",
-                          string(name), N, length(fun), fmt_ns(minimum(b.times)),
-                          mcalls, visits))
+        if nthreads > 1
+            # Bulk parallel throughput via evaluate!(ys, fun, xs)
+            ys = Vector{Float64}(undef, length(pts))
+            AdaptiveSparseGrids.evaluate!(ys, fun, pts)  # warmup
+            tp = Float64[]
+            for _ in 1:3
+                t = @elapsed AdaptiveSparseGrids.evaluate!(ys, fun, pts)
+                push!(tp, t)
+            end
+            sort!(tp); tpar = tp[2]
+            mpar = length(pts) / tpar / 1e6
+
+            println(@sprintf("%-12s | %6d | %8d | %11s | %10.2f | %12.2f | %8d",
+                              string(name), N, length(fun),
+                              fmt_ns(minimum(b.times)), mser, mpar, visits))
+        else
+            println(@sprintf("%-12s | %6d | %8d | %11s | %10.2f | %8d",
+                              string(name), N, length(fun),
+                              fmt_ns(minimum(b.times)), mser, visits))
+        end
     end
 end
 

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -441,8 +441,123 @@ function evaluate!(ys::AbstractVector, fun::AdaptiveSparseGrid,
                    xs::AbstractVector{<:Union{AbstractVector, Tuple}})
     length(ys) == length(xs) || throw(DimensionMismatch(
         "length(ys) = $(length(ys)) ≠ length(xs) = $(length(xs))"))
+    _bulk_evaluate!(ys, fun, xs)
+    return ys
+end
+
+# For scalar-codomain grids (K = 1) we run a single batch-coherent tree walk
+# that shares every node load across the whole point cloud. For multi-codomain
+# we fall back to a point-parallel walk (still thread-parallel, but one
+# traversal per point).
+_bulk_evaluate!(ys, fun::AdaptiveSparseGrid{N,1}, xs) where {N} =
+    _bulk_evaluate_batched!(ys, fun, xs)
+
+function _bulk_evaluate!(ys, fun::AdaptiveSparseGrid, xs)
     Threads.@threads for i in eachindex(xs)
         @inbounds ys[i] = fun(xs[i])
+    end
+    return ys
+end
+
+function _bulk_evaluate_batched!(ys, fun::AdaptiveSparseGrid{N,1,L,T},
+                                  xs) where {N,L,T}
+    M = length(xs)
+    M == 0 && return ys
+    fill!(ys, zero(eltype(ys)))
+
+    nth = max(1, Threads.nthreads())
+    chunk = cld(M, nth)
+
+    Threads.@threads for t in 1:nth
+        lo = (t-1)*chunk + 1
+        hi = min(M, t*chunk)
+        lo > hi && continue
+        L_chunk = hi - lo + 1
+        xs_scaled = [scale(fun, xs[i]) for i in lo:hi]
+        wrk       = ones(Float64, N, L_chunk)
+        subset    = collect(Int32(1):Int32(L_chunk))
+        saved     = Float64[]
+        left_buf  = Int32[]
+        right_buf = Int32[]
+        vys       = view(ys, lo:hi)
+        @inbounds _batch_recurse!(vys, wrk, fun._eval, fun._eval[1],
+                                   1, xs_scaled, subset,
+                                   saved, left_buf, right_buf)
+    end
+    return ys
+end
+
+# In-place batch recursion. `subset` holds 1-based Int32 indices into `xs`
+# (and `wrk`'s columns). `dimshift` is the dimension whose basis value is new
+# at this node relative to its parent; `wrk`'s other rows are valid for every
+# active point already. `saved`, `left_buf`, `right_buf` are per-thread
+# reusable scratch buffers — resized but never freshly allocated inside the
+# recursion. Partition subsets are copied once per recursion to isolate the
+# shared `left_buf`/`right_buf` state across sibling recursions.
+function _batch_recurse!(ys, wrk::Matrix{Float64},
+                         arr::Vector{EvalNode{D,K,T}},
+                         node::EvalNode{D,K,T}, dimshift::Int,
+                         xs, subset::AbstractVector{Int32},
+                         saved::Vector{Float64},
+                         left_buf::Vector{Int32},
+                         right_buf::Vector{Int32}) where {D,K,T}
+    isempty(subset) && return ys
+
+    l_ds = node.l[dimshift]; i_ds = node.i[dimshift]
+    α1 = node.α[1]
+    nsub = length(subset)
+
+    # Save the parent's wrk[dimshift, i] for restoration later (wrk is shared
+    # across sibling subtrees), then write this node's basis value.
+    resize!(saved, nsub)
+    @inbounds for (k, i) in pairs(subset)
+        saved[k] = wrk[dimshift, i]
+        wrk[dimshift, i] = ϕ(l_ds, i_ds, xs[i][dimshift])
+    end
+
+    # u[i] = prod_d wrk[d, i]; ys[i] += u * α
+    @inbounds for i in subset
+        u = 1.0
+        for d in 1:D
+            u *= wrk[d, i]
+        end
+        if u > 0
+            ys[i] += u * α1
+        end
+    end
+
+    @inbounds for d in 1:D
+        lc, rc = node.left[d], node.right[d]
+        if lc != Int32(0) || rc != Int32(0)
+            empty!(left_buf); empty!(right_buf)
+            nxd = node.x[d]
+            for i in subset
+                xd = xs[i][d]
+                if xd < nxd
+                    push!(left_buf, i)
+                elseif xd > nxd
+                    push!(right_buf, i)
+                end
+            end
+            # Copies isolate each child's view of the subset: the child
+            # recursion reuses left_buf / right_buf for its own partitioning.
+            if lc != Int32(0) && !isempty(left_buf)
+                l_copy = copy(left_buf)
+                _batch_recurse!(ys, wrk, arr, arr[lc], d, xs, l_copy,
+                                 saved, left_buf, right_buf)
+            end
+            if rc != Int32(0) && !isempty(right_buf)
+                r_copy = copy(right_buf)
+                _batch_recurse!(ys, wrk, arr, arr[rc], d, xs, r_copy,
+                                 saved, left_buf, right_buf)
+            end
+        end
+        node.l[d] > 1 && break
+    end
+
+    # Restore parent's wrk[dimshift, i] for sibling descents.
+    @inbounds for (k, i) in pairs(subset)
+        wrk[dimshift, i] = saved[k]
     end
     return ys
 end

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -449,14 +449,11 @@ function evaluate_recursive(y, wrk, node::Node{D,K,T}, dimshift, x) where {D,K,T
     return y
 end
 
-function childsplit(n::Node, x, d; inclusive=false)
-    if n.x[d] > x[d] || inclusive && n.x[d] == x[d]
-        return 1
-    elseif n.x[d] < x[d]
-        return 2
-    else
-        return 0
-    end
+function childsplit(n::Node, x, d)
+    nxd = n.x[d]; xd = x[d]
+    nxd > xd && return 1
+    nxd < xd && return 2
+    return 0
 end
 
 get(x::KTuple, i::Int)      = x[i]

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -657,14 +657,6 @@ function evaluate_recursive(y, wrk, arr::Vector{EvalNode{D,K,T}},
     return y
 end
 
-@inline function childsplit(n::Node, x, d)
-    @inbounds nxd = n.x[d]
-    @inbounds xd  = x[d]
-    nxd > xd && return 1
-    nxd < xd && return 2
-    return 0
-end
-
 @inline function childsplit(n::EvalNode, x, d)
     @inbounds nxd = n.x[d]
     @inbounds xd  = x[d]

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -397,6 +397,23 @@ evaluate!(y, wrk, fun::AdaptiveSparseGrid, x)   = evaluate_recursive(y, wrk, roo
 
 root(fun::AdaptiveSparseGrid) = fun.nodes[base(fun)]
 
+"""
+    evaluate!(ys, fun, xs)
+
+Evaluate `fun` at each point in `xs` in parallel, writing `fun(xs[i])` to
+`ys[i]`. Traversal only reads from the grid, so it's safe to call across
+threads once `fun` has been trained.
+"""
+function evaluate!(ys::AbstractVector, fun::AdaptiveSparseGrid,
+                   xs::AbstractVector{<:Union{AbstractVector, Tuple}})
+    length(ys) == length(xs) || throw(DimensionMismatch(
+        "length(ys) = $(length(ys)) ≠ length(xs) = $(length(xs))"))
+    Threads.@threads for i in eachindex(xs)
+        @inbounds ys[i] = fun(xs[i])
+    end
+    return ys
+end
+
 function makework(fun, x::AbstractVector)
     N = dims(fun,1)
     T = promote_type(Float64, eltype(x))

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -446,8 +446,10 @@ evaluate!(y, wrk, fun::AdaptiveSparseGrid, x)   = evaluate_recursive(y, wrk,    
     evaluate!(ys, fun, xs)
 
 Evaluate `fun` at each point in `xs` in parallel, writing `fun(xs[i])` to
-`ys[i]`. Traversal only reads from the grid, so it's safe to call across
-threads once `fun` has been trained.
+`ys[i]`. Traversal is read-only on the grid, so concurrent calls from
+multiple threads are safe. Do **not** call while the grid is being
+mutated (fit/refine) — `drive_to_college!` and `sync_eval!` write
+`fun.nodes` and `fun._eval`, which would race with the reading traversal.
 """
 function evaluate!(ys::AbstractVector, fun::AdaptiveSparseGrid,
                    xs::AbstractVector{<:Union{AbstractVector, Tuple}})
@@ -876,9 +878,15 @@ up-to-date eval view.
 function sync_eval!(fun::AdaptiveSparseGrid{N,K,L,T}) where {N,K,L,T}
     isempty(fun.nodes) && (empty!(fun._eval); empty!(fun._id); return fun)
 
+    # root(fun) = _eval[1] reads slot 1 unconditionally; sync relies on the
+    # root node being present in fun.nodes so slot 1 gets populated by the
+    # (idx, n) loop below. No public API deletes the root today, but guard
+    # the invariant explicitly.
+    root_idx = base(fun)
+    @assert haskey(fun.nodes, root_idx) "sync_eval!: root index missing from fun.nodes"
+
     # Assign stable positions: root → 1, then the rest in Dict order.
     empty!(fun._id); sizehint!(fun._id, length(fun.nodes))
-    root_idx = base(fun)
     fun._id[root_idx] = Int32(1)
     next::Int32 = 2
     for idx in keys(fun.nodes)
@@ -900,7 +908,9 @@ function sync_eval!(fun::AdaptiveSparseGrid{N,K,L,T}) where {N,K,L,T}
 end
 
 _eval_child_id(::Dict, ::Nothing) = Int32(0)
-_eval_child_id(id::Dict, n::Node) = Base.get(id, Index(n.l, n.i), Int32(0))
+# `n` came from the trusted tree, so skip Index's default validation (`check=false`):
+# avoids O(N·D) `m(lk)` calls across a full sync.
+_eval_child_id(id::Dict, n::Node) = Base.get(id, Index(n.l, n.i, false), Int32(0))
 
 """
 Update each new child's parent node(s) so that the parent's `children`

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -504,8 +504,10 @@ end
 # at this node relative to its parent; `wrk`'s other rows are valid for every
 # active point already. `saved`, `left_buf`, `right_buf` are per-thread
 # reusable scratch buffers — resized but never freshly allocated inside the
-# recursion. Partition subsets are copied once per recursion to isolate the
-# shared `left_buf`/`right_buf` state across sibling recursions.
+# recursion. `saved` is used as a stack: each frame pushes its snapshot at the
+# tail on entry and pops it on return, so child frames can't clobber the
+# parent's restore data. Partition subsets are copied once per recursion to
+# isolate the shared `left_buf`/`right_buf` state across sibling recursions.
 function _batch_recurse!(ys, wrk::Matrix{Float64},
                          arr::Vector{EvalNode{D,K,T}},
                          node::EvalNode{D,K,T}, dimshift::Int,
@@ -519,11 +521,12 @@ function _batch_recurse!(ys, wrk::Matrix{Float64},
     α1 = node.α[1]
     nsub = length(subset)
 
-    # Save the parent's wrk[dimshift, i] for restoration later (wrk is shared
-    # across sibling subtrees), then write this node's basis value.
-    resize!(saved, nsub)
+    # Push this frame's snapshot of wrk[dimshift, i] at the tail of `saved`
+    # (used as a stack), then write this node's basis value.
+    save_off = length(saved)
+    resize!(saved, save_off + nsub)
     @inbounds for (k, i) in pairs(subset)
-        saved[k] = wrk[dimshift, i]
+        saved[save_off + k] = wrk[dimshift, i]
         wrk[dimshift, i] = ϕ(l_ds, i_ds, xs[i][dimshift])
     end
 
@@ -551,14 +554,24 @@ function _batch_recurse!(ys, wrk::Matrix{Float64},
                     push!(right_buf, i)
                 end
             end
-            # Copies isolate each child's view of the subset: the child
-            # recursion reuses left_buf / right_buf for its own partitioning.
-            if lc != Int32(0) && !isempty(left_buf)
+            # Snapshot BOTH child subsets before any recursion. left_buf and
+            # right_buf are shared scratch — the left child's recursion
+            # reuses them for its own partitioning, clobbering right_buf and
+            # the r_copy we would otherwise take after the left recursion.
+            have_left  = lc != Int32(0) && !isempty(left_buf)
+            have_right = rc != Int32(0) && !isempty(right_buf)
+            if have_left && have_right
+                l_copy = copy(left_buf)
+                r_copy = copy(right_buf)
+                _batch_recurse!(ys, wrk, arr, arr[lc], d, xs, l_copy,
+                                 saved, left_buf, right_buf)
+                _batch_recurse!(ys, wrk, arr, arr[rc], d, xs, r_copy,
+                                 saved, left_buf, right_buf)
+            elseif have_left
                 l_copy = copy(left_buf)
                 _batch_recurse!(ys, wrk, arr, arr[lc], d, xs, l_copy,
                                  saved, left_buf, right_buf)
-            end
-            if rc != Int32(0) && !isempty(right_buf)
+            elseif have_right
                 r_copy = copy(right_buf)
                 _batch_recurse!(ys, wrk, arr, arr[rc], d, xs, r_copy,
                                  saved, left_buf, right_buf)
@@ -567,10 +580,11 @@ function _batch_recurse!(ys, wrk::Matrix{Float64},
         node.l[d] > 1 && break
     end
 
-    # Restore parent's wrk[dimshift, i] for sibling descents.
+    # Restore parent's wrk[dimshift, i] from this frame's stack slice and pop.
     @inbounds for (k, i) in pairs(subset)
-        wrk[dimshift, i] = saved[k]
+        wrk[dimshift, i] = saved[save_off + k]
     end
+    resize!(saved, save_off)
     return ys
 end
 

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -433,7 +433,7 @@ function evaluate_recursive(y, wrk, node::Node{D,K,T}, dimshift, x) where {D,K,T
 
     # Compute the product across all the dimensions
     u = 1.0
-    for d in 1:D
+    @inbounds for d in 1:D
         u *= wrk[d]
     end
 
@@ -447,7 +447,7 @@ function evaluate_recursive(y, wrk, node::Node{D,K,T}, dimshift, x) where {D,K,T
     # Children are pre-linked via node.left / node.right so traversal
     # avoids Dict lookups entirely.
     if u > 0
-        for d in 1:D
+        @inbounds for d in 1:D
             kd = childsplit(node, x, d)
             if kd > 0
                 child = kd == 1 ? node.left[d] : node.right[d]
@@ -483,7 +483,7 @@ function evaluate_recursive(wrk, node::Node{D,K,T}, dimshift, x, k) where {D,K,T
 
     # Compute the product across all the dimensions
     u = 1.0
-    for d in 1:D
+    @inbounds for d in 1:D
         u *= wrk[d]
     end
 
@@ -492,9 +492,9 @@ function evaluate_recursive(wrk, node::Node{D,K,T}, dimshift, x, k) where {D,K,T
 
     # If the contribution of this node is nonzero (x lies in the support of
     # this basis function), continue checking its children via pre-linked
-    # child pointers (children[2d-1] = left in dim d, children[2d] = right).
+    # child pointers.
     if u > 0
-        for d in 1:D
+        @inbounds for d in 1:D
             kd = childsplit(node, x, d)
             if kd > 0
                 child = kd == 1 ? node.left[d] : node.right[d]
@@ -860,7 +860,7 @@ function integrate_recursive!(y, wrk, int::AdaptiveIntegral, node::Node{D,K,T},
 
     # Product across all dimensions
     u = 1.0
-    for d in 1:D
+    @inbounds for d in 1:D
         u *= wrk[d]
     end
 
@@ -871,7 +871,7 @@ function integrate_recursive!(y, wrk, int::AdaptiveIntegral, node::Node{D,K,T},
 
     # Recurse into children via pre-linked pointers.
     if u > 0
-        for d in 1:D
+        @inbounds for d in 1:D
             dd = in(d, int.dims)
             kd = dd ? 0 : childsplit(node, x, d)
 

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -471,32 +471,50 @@ function _bulk_evaluate!(ys, fun::AdaptiveSparseGrid, xs)
     return ys
 end
 
+# `nchunks` and `threaded` are internal knobs so tests can exercise the
+# chunk-boundary logic and the Threads.@threads path independently of the
+# Julia process's nthreads setting. Defaults preserve the public behavior
+# (chunk into `Threads.nthreads()` partitions and dispatch via @threads).
 function _bulk_evaluate_batched!(ys, fun::AdaptiveSparseGrid{N,1,L,T},
-                                  xs) where {N,L,T}
+                                  xs;
+                                  nchunks::Int = max(1, Threads.nthreads()),
+                                  threaded::Bool = true) where {N,L,T}
     M = length(xs)
     M == 0 && return ys
     fill!(ys, zero(eltype(ys)))
 
-    nth = max(1, Threads.nthreads())
-    chunk = cld(M, nth)
+    nch = max(1, nchunks)
+    chunk = cld(M, nch)
 
-    Threads.@threads for t in 1:nth
-        lo = (t-1)*chunk + 1
-        hi = min(M, t*chunk)
-        lo > hi && continue
-        L_chunk = hi - lo + 1
-        xs_scaled = [scale(fun, xs[i]) for i in lo:hi]
-        wrk       = ones(Float64, N, L_chunk)
-        subset    = collect(Int32(1):Int32(L_chunk))
-        saved     = Float64[]
-        left_buf  = Int32[]
-        right_buf = Int32[]
-        vys       = view(ys, lo:hi)
-        @inbounds _batch_recurse!(vys, wrk, fun._eval, fun._eval[1],
-                                   1, xs_scaled, subset,
-                                   saved, left_buf, right_buf)
+    if threaded
+        Threads.@threads for t in 1:nch
+            _bulk_batched_chunk!(ys, fun, xs, t, chunk, M)
+        end
+    else
+        for t in 1:nch
+            _bulk_batched_chunk!(ys, fun, xs, t, chunk, M)
+        end
     end
     return ys
+end
+
+function _bulk_batched_chunk!(ys, fun::AdaptiveSparseGrid{N,1,L,T}, xs,
+                               t::Int, chunk::Int, M::Int) where {N,L,T}
+    lo = (t-1)*chunk + 1
+    hi = min(M, t*chunk)
+    lo > hi && return nothing
+    L_chunk = hi - lo + 1
+    xs_scaled = [scale(fun, xs[i]) for i in lo:hi]
+    wrk       = ones(Float64, N, L_chunk)
+    subset    = collect(Int32(1):Int32(L_chunk))
+    saved     = Float64[]
+    left_buf  = Int32[]
+    right_buf = Int32[]
+    vys       = view(ys, lo:hi)
+    @inbounds _batch_recurse!(vys, wrk, fun._eval, fun._eval[1],
+                               1, xs_scaled, subset,
+                               saved, left_buf, right_buf)
+    return nothing
 end
 
 # In-place batch recursion. `subset` holds 1-based Int32 indices into `xs`

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -159,6 +159,23 @@ end
 Node(T::KTuple, l, i) = Node(typeof(T), l, i)
 Node(l, i)            = Node(Tuple{Float64}, l, i)
 
+# Dense, bits-typed snapshot of a Node for the evaluation hot path.
+# Built from Node by sync_eval! and stored in a contiguous Vector on the
+# grid. Child links are 1-based Int32 indices into that Vector (0 means
+# no child along that dimension).
+#
+# Cold metadata (fx, depth) stays on the mutable Node used during fit!;
+# EvalNode holds only what evaluate_recursive / integrate_recursive!
+# actually read.
+struct EvalNode{D, K, T<:KTuple{K}}
+    α::T
+    x::SVector{D, Float64}
+    l::NTuple{D, Int}
+    i::NTuple{D, Int}
+    left::NTuple{D, Int32}
+    right::NTuple{D, Int32}
+end
+
 getx(n::Node) = n.x
 getT(::Node{N,K,T}) where {N,K,T} = T
 dims(fun::Node{N,K,T}) where {N,K,T} = (N, K)
@@ -192,7 +209,8 @@ function rightchild(idx::Int, p::Node{D,K}, d) where {D, K}
                 (p.i[1:d-1]..., ic, p.i[d+1:end]...))
 end
 
-ϕ(p::Node, x, d) = ϕ(p.l[d], p.i[d], x[d])
+ϕ(p::Node,     x, d) = ϕ(p.l[d], p.i[d], x[d])
+ϕ(p::EvalNode, x, d) = ϕ(p.l[d], p.i[d], x[d])
 
 function ϕ(p::Node, x)
     D, K = dims(p)
@@ -264,11 +282,23 @@ for f in [:leftchild, :rightchild, :parent]
     end
 end
 
-mutable struct AdaptiveSparseGrid{N, K, L, T} 
+mutable struct AdaptiveSparseGrid{N, K, L, T}
     nodes::Dict{Index{N}, Node{N, K, T}}
     bounds::SMatrix{N, 2, Float64, L}
     depth::Int
     max_depth::Int
+    # Flat eval view. Slot 1 is always the root. Kept in sync with `nodes`
+    # by `sync_eval!`, which runs after every `drive_to_college!`.
+    _eval::Vector{EvalNode{N, K, T}}
+    _id::Dict{Index{N}, Int32}
+end
+
+function AdaptiveSparseGrid(nodes::Dict{Index{N}, Node{N,K,T}}, bounds::SMatrix{N,2,Float64,L},
+                             depth::Int, max_depth::Int) where {N,K,L,T}
+    fun = AdaptiveSparseGrid{N,K,L,T}(nodes, bounds, depth, max_depth,
+                                       EvalNode{N,K,T}[], Dict{Index{N}, Int32}())
+    sync_eval!(fun)
+    return fun
 end
 
 getT(::AdaptiveSparseGrid{N,K,L,T}) where {N,K,L,T} = T
@@ -393,11 +423,12 @@ function evaluate(fun::AdaptiveSparseGrid, x)
     evaluate!(y, fun, x)
 end
 
-evaluate(fun::AdaptiveSparseGrid, x, k)         = evaluate_recursive(makework(fun,x),    root(fun), 1, x, k)
-evaluate!(y, fun::AdaptiveSparseGrid, x)        = evaluate_recursive(y, makework(fun,x), root(fun), 1, x)
-evaluate!(y, wrk, fun::AdaptiveSparseGrid, x)   = evaluate_recursive(y, wrk, root(fun), 1, x)
+evaluate(fun::AdaptiveSparseGrid, x, k)         = evaluate_recursive(makework(fun,x),    fun._eval, root(fun), 1, x, k)
+evaluate!(y, fun::AdaptiveSparseGrid, x)        = evaluate_recursive(y, makework(fun,x), fun._eval, root(fun), 1, x)
+evaluate!(y, wrk, fun::AdaptiveSparseGrid, x)   = evaluate_recursive(y, wrk,             fun._eval, root(fun), 1, x)
 
-root(fun::AdaptiveSparseGrid) = fun.nodes[base(fun)]
+# Root EvalNode lives in slot 1 of _eval (invariant maintained by sync_eval!).
+@inline root(fun::AdaptiveSparseGrid) = @inbounds fun._eval[1]
 
 """
     evaluate!(ys, fun, xs)
@@ -428,7 +459,8 @@ function makework(fun, x)
     return @SVector ones(T, N)
 end
 
-function evaluate_recursive(y, wrk, node::Node{D,K,T}, dimshift, x) where {D,K,T}
+function evaluate_recursive(y, wrk, arr::Vector{EvalNode{D,K,T}},
+                             node::EvalNode{D,K,T}, dimshift, x) where {D,K,T}
     # We have stored the basis function evaluations for every dimension except
     # dimshift
     wrk = setindex(wrk, ϕ(node, x, dimshift), dimshift)
@@ -444,17 +476,15 @@ function evaluate_recursive(y, wrk, node::Node{D,K,T}, dimshift, x) where {D,K,T
         y = setindex(y, y[k] + u * node.α[k], k)
     end
 
-    # If the contribution of this node is nonzero (i.e, x lies in the support
-    # of this basis function), then we continue checking its children.
-    # Children are pre-linked via node.left / node.right so traversal
-    # avoids Dict lookups entirely.
+    # Descend into children via Int32 indices into the flat array.
+    # A child id of 0 means no child along that side/dimension.
     if u > 0
         @inbounds for d in 1:D
             kd = childsplit(node, x, d)
             if kd > 0
-                child = kd == 1 ? node.left[d] : node.right[d]
-                if child !== nothing
-                    y = evaluate_recursive(y, wrk, child, d, x)
+                cid = kd == 1 ? node.left[d] : node.right[d]
+                if cid != Int32(0)
+                    y = evaluate_recursive(y, wrk, arr, arr[cid], d, x)
                 end
             end
 
@@ -475,33 +505,34 @@ function childsplit(n::Node, x, d)
     return 0
 end
 
+function childsplit(n::EvalNode, x, d)
+    nxd = n.x[d]; xd = x[d]
+    nxd > xd && return 1
+    nxd < xd && return 2
+    return 0
+end
+
 get(x::KTuple, i::Int)      = x[i]
 get(x::KTuple, s::Symbol)   = getproperty(x, s)
 
-function evaluate_recursive(wrk, node::Node{D,K,T}, dimshift, x, k) where {D,K,T}
-    # We have stored the basis function evaluations for every dimension except
-    # dimshift
+function evaluate_recursive(wrk, arr::Vector{EvalNode{D,K,T}},
+                             node::EvalNode{D,K,T}, dimshift, x, k) where {D,K,T}
     wrk = setindex(wrk, ϕ(node, x, dimshift), dimshift)
 
-    # Compute the product across all the dimensions
     u = 1.0
     @inbounds for d in 1:D
         u *= wrk[d]
     end
 
-    # Add in the contribution of this node to the running sum
     y = u * get(node.α, k)
 
-    # If the contribution of this node is nonzero (x lies in the support of
-    # this basis function), continue checking its children via pre-linked
-    # child pointers.
     if u > 0
         @inbounds for d in 1:D
             kd = childsplit(node, x, d)
             if kd > 0
-                child = kd == 1 ? node.left[d] : node.right[d]
-                if child !== nothing
-                    y += evaluate_recursive(wrk, child, d, x, k)
+                cid = kd == 1 ? node.left[d] : node.right[d]
+                if cid != Int32(0)
+                    y += evaluate_recursive(wrk, arr, arr[cid], d, x, k)
                 end
             end
 
@@ -521,6 +552,10 @@ end
 function fit!(f, fun::AdaptiveSparseGrid; kwargs...)
     # We need to evaluate f on the base node
     train!(f, fun, collect(values(fun.nodes)))
+    # The root node was already in fun.nodes before fit!, so drive_to_college!
+    # (which is the normal sync point) never fired for it. Capture its
+    # freshly-trained α in the flat _eval view before the first refine step.
+    sync_eval!(fun)
 
     while true
         n = refinegrid!(f, fun; kwargs...)
@@ -675,7 +710,44 @@ function drive_to_college!(fun, children)
         fun.nodes[Index(child.l, child.i)] = child
     end
     link_to_parents!(fun, children)
+    sync_eval!(fun)
 end
+
+"""
+Rebuild the flat `_eval` vector from the current mutable `nodes` Dict.
+Slot 1 always holds the root (the all-ones Index). This is invoked after
+every `drive_to_college!` so subsequent `evaluate` calls (used inside
+`train!` to compute the current approximation at new points) see an
+up-to-date eval view.
+"""
+function sync_eval!(fun::AdaptiveSparseGrid{N,K,L,T}) where {N,K,L,T}
+    isempty(fun.nodes) && (empty!(fun._eval); empty!(fun._id); return fun)
+
+    # Assign stable positions: root → 1, then the rest in Dict order.
+    empty!(fun._id); sizehint!(fun._id, length(fun.nodes))
+    root_idx = base(fun)
+    fun._id[root_idx] = Int32(1)
+    next::Int32 = 2
+    for idx in keys(fun.nodes)
+        idx == root_idx && continue
+        fun._id[idx] = next
+        next += Int32(1)
+    end
+
+    resize!(fun._eval, length(fun.nodes))
+    for (idx, n) in fun.nodes
+        id = fun._id[idx]
+        fun._eval[id] = EvalNode{N,K,T}(
+            n.α, n.x, n.l, n.i,
+            ntuple(d -> _eval_child_id(fun._id, n.left[d]),  Val(N)),
+            ntuple(d -> _eval_child_id(fun._id, n.right[d]), Val(N)),
+        )
+    end
+    return fun
+end
+
+_eval_child_id(::Dict, ::Nothing) = Int32(0)
+_eval_child_id(id::Dict, n::Node) = Base.get(id, Index(n.l, n.i), Int32(0))
 
 """
 Update each new child's parent node(s) so that the parent's `children`
@@ -837,7 +909,7 @@ function integrate(int::AdaptiveIntegral, x)
     T    = promote_type(eltype(x), Float64)
     y    = @SVector zeros(T, dims(int.fun, 2))
     wrk  = makework(int.fun, x)
-    return integrate_recursive!(y, wrk, int, root(int.fun), 1, x)
+    return integrate_recursive!(y, wrk, int, int.fun._eval, root(int.fun), 1, x)
 end
 
 function scale(int::AdaptiveIntegral, x)
@@ -852,7 +924,9 @@ function scale(int::AdaptiveIntegral, x)
 end
 
 
-function integrate_recursive!(y, wrk, int::AdaptiveIntegral, node::Node{D,K,T},
+function integrate_recursive!(y, wrk, int::AdaptiveIntegral,
+                               arr::Vector{EvalNode{D,K,T}},
+                               node::EvalNode{D,K,T},
                                dimshift, x) where {D,K,T}
     # Integration dim? Use basis integral; else evaluate basis at x.
     newval = in(dimshift, int.dims) ?
@@ -860,18 +934,15 @@ function integrate_recursive!(y, wrk, int::AdaptiveIntegral, node::Node{D,K,T},
                 ϕ(node, x, dimshift)
     wrk = setindex(wrk, newval, dimshift)
 
-    # Product across all dimensions
     u = 1.0
     @inbounds for d in 1:D
         u *= wrk[d]
     end
 
-    # Accumulate this node's contribution
     @inbounds @simd for k in 1:K
         y = setindex(y, y[k] + u * node.α[k], k)
     end
 
-    # Recurse into children via pre-linked pointers.
     if u > 0
         @inbounds for d in 1:D
             dd = in(d, int.dims)
@@ -879,9 +950,9 @@ function integrate_recursive!(y, wrk, int::AdaptiveIntegral, node::Node{D,K,T},
 
             for split in 1:2
                 !dd && kd != split && continue
-                child = split == 1 ? node.left[d] : node.right[d]
-                if child !== nothing
-                    y = integrate_recursive!(y, wrk, int, child, d, x)
+                cid = split == 1 ? node.left[d] : node.right[d]
+                if cid != Int32(0)
+                    y = integrate_recursive!(y, wrk, int, arr, arr[cid], d, x)
                 end
             end
 
@@ -901,7 +972,8 @@ function I(l)
     throw(ArgumentError("l must be positive"))
 end
 
-I(n::Node, d) = I(n.l[d])
+I(n::Node,     d) = I(n.l[d])
+I(n::EvalNode, d) = I(n.l[d])
 ################################################################################
 ##################### Helper Utilities #########################################
 ################################################################################

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -18,6 +18,11 @@ function m(i::Int)
     throw(ArgumentError("i must be a nonnegative integer.  You passed $i"))
 end
 
+# Unchecked hot-path variant. Only valid for i >= 1; used by ϕ / I on
+# grid nodes where `l[d]` is always >= 1. Dropping the throw branch
+# lets LLVM eliminate the GC-frame setup inside evaluate_recursive.
+@inline _m(i::Int) = i > 1 ? (2 << (i-2)) : 1
+
 function Y(i::Int,j::Int)
     # Recover the dimension of the ith layer
     mi = m(i)
@@ -51,13 +56,20 @@ function Dϕ(x::Real)
 end
 
 
-function ϕ(i,j,x)
-    i > 2               && return ϕ(x*m(i) - j)
-    i == 2 && j == 0    && return 0.0 <= x <= 0.5 ?  1 - 2 * x : 0.0
-    i == 2 && j == 2    && return 0.5 <= x <= 1   ?  2 * x - 1 : 0.0
-    i == 2 && j == 1    && return ϕ(2*x - 1)
-    i == 1              && return 0.0 <= x <= 1   ? 1.0 : 0.0
-    throw(ArgumentError("i=$i, j=$j are not valid indices"))
+@inline function ϕ(i, j, x)
+    # No throw path: LLVM would otherwise emit a GC frame for the
+    # ArgumentError string interpolation even though the branch is
+    # unreachable with well-formed (l, i) on the grid. Only call
+    # with a valid (i, j) pair; this is internal.
+    if i > 2
+        return ϕ(x*_m(i) - j)
+    elseif i == 2
+        j == 0 && return 0.0 <= x <= 0.5 ? 1 - 2*x : 0.0
+        j == 2 && return 0.5 <= x <= 1   ? 2*x - 1 : 0.0
+        return ϕ(2*x - 1)            # j == 1
+    else                             # i == 1
+        return 0.0 <= x <= 1 ? 1.0 : 0.0
+    end
 end
 
 ϕ(i::Int, j::Int) = x -> ϕ(i,j,x)
@@ -209,8 +221,8 @@ function rightchild(idx::Int, p::Node{D,K}, d) where {D, K}
                 (p.i[1:d-1]..., ic, p.i[d+1:end]...))
 end
 
-ϕ(p::Node,     x, d) = ϕ(p.l[d], p.i[d], x[d])
-ϕ(p::EvalNode, x, d) = ϕ(p.l[d], p.i[d], x[d])
+@inline ϕ(p::Node,     x, d) = @inbounds ϕ(p.l[d], p.i[d], x[d])
+@inline ϕ(p::EvalNode, x, d) = @inbounds ϕ(p.l[d], p.i[d], x[d])
 
 function ϕ(p::Node, x)
     D, K = dims(p)
@@ -578,7 +590,7 @@ function evaluate_recursive(y, wrk, arr::Vector{EvalNode{D,K,T}},
                              node::EvalNode{D,K,T}, dimshift, x) where {D,K,T}
     # We have stored the basis function evaluations for every dimension except
     # dimshift
-    wrk = setindex(wrk, ϕ(node, x, dimshift), dimshift)
+    wrk = @inbounds setindex(wrk, ϕ(node, x, dimshift), dimshift)
 
     # Compute the product across all the dimensions
     u = 1.0
@@ -613,15 +625,17 @@ function evaluate_recursive(y, wrk, arr::Vector{EvalNode{D,K,T}},
     return y
 end
 
-function childsplit(n::Node, x, d)
-    nxd = n.x[d]; xd = x[d]
+@inline function childsplit(n::Node, x, d)
+    @inbounds nxd = n.x[d]
+    @inbounds xd  = x[d]
     nxd > xd && return 1
     nxd < xd && return 2
     return 0
 end
 
-function childsplit(n::EvalNode, x, d)
-    nxd = n.x[d]; xd = x[d]
+@inline function childsplit(n::EvalNode, x, d)
+    @inbounds nxd = n.x[d]
+    @inbounds xd  = x[d]
     nxd > xd && return 1
     nxd < xd && return 2
     return 0
@@ -632,14 +646,14 @@ get(x::KTuple, s::Symbol)   = getproperty(x, s)
 
 function evaluate_recursive(wrk, arr::Vector{EvalNode{D,K,T}},
                              node::EvalNode{D,K,T}, dimshift, x, k) where {D,K,T}
-    wrk = setindex(wrk, ϕ(node, x, dimshift), dimshift)
+    wrk = @inbounds setindex(wrk, ϕ(node, x, dimshift), dimshift)
 
     u = 1.0
     @inbounds for d in 1:D
         u *= wrk[d]
     end
 
-    y = u * get(node.α, k)
+    y = u * @inbounds(get(node.α, k))
 
     if u > 0
         @inbounds for d in 1:D
@@ -1047,7 +1061,7 @@ function integrate_recursive!(y, wrk, int::AdaptiveIntegral,
     newval = in(dimshift, int.dims) ?
                 I(node, dimshift)  :
                 ϕ(node, x, dimshift)
-    wrk = setindex(wrk, newval, dimshift)
+    wrk = @inbounds setindex(wrk, newval, dimshift)
 
     u = 1.0
     @inbounds for d in 1:D
@@ -1080,15 +1094,16 @@ function integrate_recursive!(y, wrk, int::AdaptiveIntegral,
     return y
 end
 
-function I(l)
-    l >  2 && return 1/(2 << (l-2))
+@inline function I(l)
+    # Hot path from integrate_recursive!. Only called with l >= 1 on
+    # the grid; no throw branch so LLVM can drop the GC frame.
+    l > 2  && return 1/(2 << (l-2))
     l == 2 && return 1/4
-    l == 1 && return 1.0
-    throw(ArgumentError("l must be positive"))
+    return 1.0                     # l == 1
 end
 
-I(n::Node,     d) = I(n.l[d])
-I(n::EvalNode, d) = I(n.l[d])
+@inline I(n::Node,     d) = @inbounds I(n.l[d])
+@inline I(n::EvalNode, d) = @inbounds I(n.l[d])
 ################################################################################
 ##################### Helper Utilities #########################################
 ################################################################################

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -112,7 +112,27 @@ mutable struct Node{D,K,T<:KTuple{K}}
     l::NTuple{D, Int}
     i::NTuple{D, Int}
     depth::Int
+    # Pre-linked children along each dimension. left[d] / right[d] hold
+    # the left / right child in dimension d, or `nothing` if no such child
+    # exists in the grid. Populated by link_to_parents! as nodes are
+    # inserted; consumed by evaluate_recursive / integrate_recursive! so
+    # traversal avoids Dict lookups entirely.
+    left::NTuple{D, Union{Nothing, Node{D,K,T}}}
+    right::NTuple{D, Union{Nothing, Node{D,K,T}}}
+
+    function Node{D,K,T}(α::T, x::SVector{D,Float64}, fx::T,
+                         l::NTuple{D,Int}, i::NTuple{D,Int},
+                         depth::Int) where {D,K,T<:KTuple{K}}
+        CT  = NTuple{D, Union{Nothing, Node{D,K,T}}}
+        nils = CT(nothing for _ in 1:D)
+        return new{D,K,T}(α, x, fx, l, i, depth, nils, nils)
+    end
 end
+
+# Outer constructor so existing call sites don't need to know the
+# type parameters explicitly.
+Node(α::T, x::SVector{D,Float64}, fx::T, l::NTuple{D,Int}, i::NTuple{D,Int},
+     depth::Int) where {D,K,T<:KTuple{K}} = Node{D,K,T}(α, x, fx, l, i, depth)
 
 function Node(T::Type{S}, l, i) where {S <: KTuple}
     lt = Tuple(l)
@@ -371,9 +391,11 @@ function evaluate(fun::AdaptiveSparseGrid, x)
     evaluate!(y, fun, x)
 end
 
-evaluate(fun::AdaptiveSparseGrid, x, k)         = evaluate_recursive(makework(fun,x),    fun, base(fun), 1, x, k)
-evaluate!(y, fun::AdaptiveSparseGrid, x)        = evaluate_recursive(y, makework(fun,x), fun, base(fun), 1, x)
-evaluate!(y, wrk, fun::AdaptiveSparseGrid, x)   = evaluate_recursive(y, wrk, fun, base(fun), 1, x)
+evaluate(fun::AdaptiveSparseGrid, x, k)         = evaluate_recursive(makework(fun,x),    root(fun), 1, x, k)
+evaluate!(y, fun::AdaptiveSparseGrid, x)        = evaluate_recursive(y, makework(fun,x), root(fun), 1, x)
+evaluate!(y, wrk, fun::AdaptiveSparseGrid, x)   = evaluate_recursive(y, wrk, root(fun), 1, x)
+
+root(fun::AdaptiveSparseGrid) = fun.nodes[base(fun)]
 
 function makework(fun, x::AbstractVector)
     N = dims(fun,1)
@@ -387,21 +409,14 @@ function makework(fun, x)
     return @SVector ones(T, N)
 end
 
-function evaluate_recursive(y, wrk, fun::AdaptiveSparseGrid, idx::Index, dimshift, x)
-    # Dimensions of domain/codomain
-    N, K = dims(fun)
-
-    # Get the node that we're working on now
-    node  = fun.nodes[idx]
-    depth = node.depth
-
+function evaluate_recursive(y, wrk, node::Node{D,K,T}, dimshift, x) where {D,K,T}
     # We have stored the basis function evaluations for every dimension except
-    # dimshift 
-    wrk = setindex(wrk, ϕ(node, x, dimshift),   dimshift)
+    # dimshift
+    wrk = setindex(wrk, ϕ(node, x, dimshift), dimshift)
 
     # Compute the product across all the dimensions
     u = 1.0
-    for d in 1:N
+    for d in 1:D
         u *= wrk[d]
     end
 
@@ -410,31 +425,22 @@ function evaluate_recursive(y, wrk, fun::AdaptiveSparseGrid, idx::Index, dimshif
         y = setindex(y, y[k] + u * node.α[k], k)
     end
 
-    # If the contribution of this node is nonzero (i.e, x lies in the support of
-    # this basis function), then we continue checking all of it's children
+    # If the contribution of this node is nonzero (i.e, x lies in the support
+    # of this basis function), then we continue checking its children.
+    # Children are pre-linked via node.left / node.right so traversal
+    # avoids Dict lookups entirely.
     if u > 0
-        for d in 1:N
-
-            # Figure out which side we need to be on
+        for d in 1:D
             kd = childsplit(node, x, d)
-
-            # Calculate the index of the left or right child in dimension d
             if kd > 0
-                if kd == 1
-                    child = leftchild(idx, d)
-                else
-                    child = rightchild(idx, d)
-                end
-
-                # Check if that node is in the tree -- if it is, then descend into
-                # it
-                if haskey(fun.nodes, child)
-                    y = evaluate_recursive(y, wrk, fun, child, d, x)
+                child = kd == 1 ? node.left[d] : node.right[d]
+                if child !== nothing
+                    y = evaluate_recursive(y, wrk, child, d, x)
                 end
             end
 
-            # We descend through the nodes lexicographically
-            if idx[1][d] > 1
+            # Descend through the nodes lexicographically
+            if node.l[d] > 1
                 break
             end
         end
@@ -456,53 +462,34 @@ end
 get(x::KTuple, i::Int)      = x[i]
 get(x::KTuple, s::Symbol)   = getproperty(x, s)
 
-function evaluate_recursive(wrk, fun::AdaptiveSparseGrid, idx::Index, dimshift, x, k)
-    # Dimensions of domain/codomain
-    N, K = dims(fun)
-
-    # Get the node that we're working on now
-    node  = fun.nodes[idx]
-    depth = node.depth
-
+function evaluate_recursive(wrk, node::Node{D,K,T}, dimshift, x, k) where {D,K,T}
     # We have stored the basis function evaluations for every dimension except
-    # dimshift 
-    wrk = setindex(wrk, ϕ(node, x, dimshift),   dimshift)
+    # dimshift
+    wrk = setindex(wrk, ϕ(node, x, dimshift), dimshift)
 
     # Compute the product across all the dimensions
     u = 1.0
-    for d in 1:N 
+    for d in 1:D
         u *= wrk[d]
     end
 
-    # Add in the the contribution of this node to the running sum
+    # Add in the contribution of this node to the running sum
     y = u * get(node.α, k)
 
-    # If the contribution of this node is nonzero (i.e, x lies in the support of
-    # this basis function), then we continue checking all of it's children
+    # If the contribution of this node is nonzero (x lies in the support of
+    # this basis function), continue checking its children via pre-linked
+    # child pointers (children[2d-1] = left in dim d, children[2d] = right).
     if u > 0
-        for d in 1:N
-
-            # Figure out which side we need to be on
+        for d in 1:D
             kd = childsplit(node, x, d)
             if kd > 0
-
-                # Calculate the index of the left or right child in dimension d
-                if kd == 1
-                    child = leftchild(idx, d)
-                else
-                    child = rightchild(idx, d)
+                child = kd == 1 ? node.left[d] : node.right[d]
+                if child !== nothing
+                    y += evaluate_recursive(wrk, child, d, x, k)
                 end
-
-                # Check if that node is in the tree -- if it is, then descend into
-                # it
-                if haskey(fun.nodes, child)
-                    y += evaluate_recursive(wrk, fun, child, d, x, k)
-                end
-
             end
 
-            # We descend through the nodes lexicographically
-            if idx[1][d] > 1
+            if node.l[d] > 1
                 break
             end
         end
@@ -671,6 +658,48 @@ function drive_to_college!(fun, children)
     for child in children
         fun.nodes[Index(child.l, child.i)] = child
     end
+    link_to_parents!(fun, children)
+end
+
+"""
+Update each new child's parent node(s) so that the parent's `children`
+field points to this child in the appropriate slot. This maintains the
+invariant `evaluate_recursive` relies on: if a child exists in `fun.nodes`
+then its parent's corresponding `children` slot holds a reference to it
+(and the slot is `nothing` otherwise).
+"""
+function link_to_parents!(fun, new_children)
+    for c in new_children
+        D = length(c.l)
+        for d in 1:D
+            c.l[d] == 1 && continue
+            p_idx = parent(Index(c.l, c.i), d)
+            p = Base.get(fun.nodes, p_idx, nothing)
+            p === nothing && continue
+            p_l_d = p.l[d]; p_i_d = p.i[d]
+            lch_ld, lch_id = leftchild(p_l_d, p_i_d)
+            if (c.l[d], c.i[d]) == (lch_ld, lch_id)
+                _set_left!(p, d, c)
+            else
+                rch_ld, rch_id = rightchild(p_l_d, p_i_d)
+                if (c.l[d], c.i[d]) == (rch_ld, rch_id)
+                    _set_right!(p, d, c)
+                end
+            end
+        end
+    end
+end
+
+function _set_left!(p::Node{D,K,T}, d::Int, c::Node{D,K,T}) where {D,K,T}
+    old = p.left
+    p.left = ntuple(s -> s == d ? c : old[s], Val(D))
+    return
+end
+
+function _set_right!(p::Node{D,K,T}, d::Int, c::Node{D,K,T}) where {D,K,T}
+    old = p.right
+    p.right = ntuple(s -> s == d ? c : old[s], Val(D))
+    return
 end
 
 function addchildren!(children, node, d)
@@ -792,7 +821,7 @@ function integrate(int::AdaptiveIntegral, x)
     T    = promote_type(eltype(x), Float64)
     y    = @SVector zeros(T, dims(int.fun, 2))
     wrk  = makework(int.fun, x)
-    return integrate_recursive!(y, wrk, int, base(int.fun), 1, x)
+    return integrate_recursive!(y, wrk, int, root(int.fun), 1, x)
 end
 
 function scale(int::AdaptiveIntegral, x)
@@ -807,64 +836,40 @@ function scale(int::AdaptiveIntegral, x)
 end
 
 
-function integrate_recursive!(y, wrk, int::AdaptiveIntegral, idx::Index, dimshift, x)
-    # Dimensions of domain/codomain
-    fun  = int.fun
-    N, K = dims(fun)
-
-    # Get the node that we're working on now
-    @inbounds node  = fun.nodes[idx]
-    @inbounds depth = node.depth
-
-    # We have stored the basis function evaluations for every dimension except
-    # dimshift 
+function integrate_recursive!(y, wrk, int::AdaptiveIntegral, node::Node{D,K,T},
+                               dimshift, x) where {D,K,T}
+    # Integration dim? Use basis integral; else evaluate basis at x.
     newval = in(dimshift, int.dims) ?
-                I(node,dimshift)     :
+                I(node, dimshift)  :
                 ϕ(node, x, dimshift)
-    wrk = setindex(wrk, newval,   dimshift)
-    
-    # Compute the product across all the dimensions
+    wrk = setindex(wrk, newval, dimshift)
+
+    # Product across all dimensions
     u = 1.0
-    for d in 1:N
+    for d in 1:D
         u *= wrk[d]
     end
 
-    # Add in the the contribution of this node to the running sum
+    # Accumulate this node's contribution
     @inbounds @simd for k in 1:K
         y = setindex(y, y[k] + u * node.α[k], k)
     end
 
-    # If the contribution of this node is nonzero (i.e, x lies in the support of
-    # this basis function), then we continue checking all of it's children
+    # Recurse into children via pre-linked pointers.
     if u > 0
-        for d in 1:N
-
-            # Are we considering in an integration dimension
+        for d in 1:D
             dd = in(d, int.dims)
-
-            # If not, we can compute which side to split along
-            if !dd
-                kd = childsplit(node, x, d)
-            end
+            kd = dd ? 0 : childsplit(node, x, d)
 
             for split in 1:2
                 !dd && kd != split && continue
-
-                if split == 1
-                    child = leftchild(idx, d)
-                else
-                    child = rightchild(idx, d)
-                end
-
-                # Check if that node is in the tree -- if it is, then descend into
-                # it
-                if haskey(fun.nodes, child)
+                child = split == 1 ? node.left[d] : node.right[d]
+                if child !== nothing
                     y = integrate_recursive!(y, wrk, int, child, d, x)
                 end
             end
 
-            # We descend through the nodes lexicographically
-            if idx[1][d] > 1
+            if node.l[d] > 1
                 break
             end
         end

--- a/src/AdaptiveSparseGrids.jl
+++ b/src/AdaptiveSparseGrids.jl
@@ -106,12 +106,10 @@ KTuple{N,T} = Union{NTuple{N,T},
 KTuple{N}   = KTuple{N,T} where T
 
 mutable struct Node{D,K,T<:KTuple{K}}
+    # --- Hot fields (accessed on every eval/integrate visit) ---
     α::T
     x::SVector{D, Float64}
-    fx::T
     l::NTuple{D, Int}
-    i::NTuple{D, Int}
-    depth::Int
     # Pre-linked children along each dimension. left[d] / right[d] hold
     # the left / right child in dimension d, or `nothing` if no such child
     # exists in the grid. Populated by link_to_parents! as nodes are
@@ -119,13 +117,17 @@ mutable struct Node{D,K,T<:KTuple{K}}
     # traversal avoids Dict lookups entirely.
     left::NTuple{D, Union{Nothing, Node{D,K,T}}}
     right::NTuple{D, Union{Nothing, Node{D,K,T}}}
+    # --- Cold fields (fit-only) ---
+    fx::T
+    i::NTuple{D, Int}
+    depth::Int
 
     function Node{D,K,T}(α::T, x::SVector{D,Float64}, fx::T,
                          l::NTuple{D,Int}, i::NTuple{D,Int},
                          depth::Int) where {D,K,T<:KTuple{K}}
         CT  = NTuple{D, Union{Nothing, Node{D,K,T}}}
         nils = CT(nothing for _ in 1:D)
-        return new{D,K,T}(α, x, fx, l, i, depth, nils, nils)
+        return new{D,K,T}(α, x, l, nils, nils, fx, i, depth)
     end
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -409,6 +409,31 @@ end
         @test maximum(abs, ys .- expected) < rtol
     end
 
+    @testset "Chunking invariance" begin
+        # Correctness of the batched bulk path must be independent of how we
+        # partition the point cloud into chunks and of whether we dispatch
+        # those chunks through Threads.@threads or a serial loop. This test
+        # exercises the chunking logic deterministically even when CI runs
+        # under a single thread (the default), which would otherwise make
+        # the chunk-boundary branches unreachable.
+        import AdaptiveSparseGrids: _bulk_evaluate_batched!
+        g((x,y)) = exp(-(x^2 + y^2))
+        fun = AdaptiveSparseGrid(g, [-1.0, -1.0], [1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+        rng = MersenneTwister(20260419)
+        pts = [(-1 + 2*rand(rng), -1 + 2*rand(rng)) for _ in 1:150]
+        expected = [fun(p) for p in pts]
+
+        # nchunks=1: no chunking. nchunks=3,7: typical multi-chunk.
+        # nchunks=200 > length(pts): exercises the lo > hi empty-chunk branch.
+        for nchunks in (1, 3, 7, 200), threaded in (false, true)
+            ys = zeros(length(pts))
+            _bulk_evaluate_batched!(ys, fun, pts;
+                                     nchunks = nchunks, threaded = threaded)
+            @test maximum(abs, ys .- expected) < rtol
+        end
+    end
+
     @testset "Multi-codomain matches per-point" begin
         # K > 1 uses the point-parallel fallback path but should still agree
         # with per-point evaluation.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -442,6 +442,69 @@ end
     end
 end
 
+@testset "Partial Integration (multi-D)" begin
+    # 1D `AdaptiveIntegral` has `dims == {1}`, so in `integrate_recursive!`
+    # every dim is an integration dim (`dd = true`) and the `!dd` branch
+    # (partial integration via `childsplit` + single-child descent) is never
+    # exercised. The rewritten EvalNode traversal could have a latent bug
+    # there. These tests build multi-D integrals with a strict subset of
+    # integrated dims to hit both branches.
+
+    rtol = 1e-6
+
+    @testset "2D integrand, integrate dim 1" begin
+        # g(x,y) = sin(x) * cos(y); integrate over x ∈ [0, π]
+        # Expected: (∫₀^π sin dx) * cos(y) = 2 * cos(y)
+        g((x,y)) = sin(x) * cos(y)
+        int = AdaptiveIntegral(g, [0.0, 0.0], [π, 2π], 1,
+                               tol=1e-8, max_depth=15)
+        for y in LinRange(0, 2π, 11)
+            got      = int([y])
+            expected = 2 * cos(y)
+            @test abs(got[1] - expected) < rtol
+        end
+    end
+
+    @testset "2D integrand, integrate dim 2" begin
+        # Integrate the SECOND dim — sanity-checks that `dimshift` indexing
+        # into int.dims works for non-leading integrated dims.
+        g((x,y)) = sin(x) * cos(y)
+        int = AdaptiveIntegral(g, [0.0, 0.0], [π, 2π], 2,
+                               tol=1e-8, max_depth=15)
+        # ∫₀^{2π} cos(y) dy = 0, so expected = 0 for all x
+        for x in LinRange(0, π, 11)
+            got = int([x])
+            @test abs(got[1]) < rtol
+        end
+    end
+
+    @testset "3D integrand, integrate dims (1,3)" begin
+        # dd = (1,3) — `!dd` branch fires on dim 2 while `dd` fires on 1 and 3.
+        # g(x,y,z) = sin(x) * cos(y) * exp(z); integrate over x ∈ [0,π], z ∈ [0,1]
+        # Expected: 2 * cos(y) * (e - 1)
+        g((x,y,z)) = sin(x) * cos(y) * exp(z)
+        int = AdaptiveIntegral(g, [0.0, 0.0, 0.0], [π, 2π, 1.0], (1, 3),
+                               tol=1e-5, max_depth=12)
+        for y in LinRange(0, 2π, 7)
+            got      = int([y])
+            expected = 2 * cos(y) * (ℯ - 1)
+            @test abs(got[1] - expected) / max(abs(expected), 1) < 1e-4
+        end
+    end
+
+    @testset "3D integrand, integrate middle dim only" begin
+        # dd = (2,) — exercises two `!dd` dims (1 and 3) around one `dd` dim.
+        g((x,y,z)) = sin(x) * cos(y) * exp(z)
+        int = AdaptiveIntegral(g, [0.0, 0.0, 0.0], [π, 2π, 1.0], 2,
+                               tol=1e-5, max_depth=12)
+        # ∫₀^{2π} cos(y) dy = 0
+        for x in LinRange(0, π, 5), z in LinRange(0, 1, 5)
+            got = int([x, z])
+            @test abs(got[1]) < 1e-4
+        end
+    end
+end
+
 
 @testset "Interpolation Tests (2D)" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,9 @@ using QuadGK
     end
 
     @testset "Dϕ: Derivatives" begin
-        for x in LinRange(-1, 1, 5)
+        # Only interior points: ϕ has kinks at x ∈ {-1, 0, 1} and ForwardDiff's
+        # convention for abs'(0) differs from the one-sided value we return.
+        for x in [-0.9, -0.4, 0.3, 0.6, 0.9]
             @test Dϕ(x) == ForwardDiff.derivative(ϕ, x)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -450,6 +450,97 @@ end
 
         @test all(ys[i] == expected[i] for i in eachindex(pts))
     end
+
+    @testset "SVector input" begin
+        # The README example uses SVector points; make sure dispatch picks
+        # up the bulk path for that element type.
+        g((x,y,z)) = sin(x) + cos(y) * z
+        fun = AdaptiveSparseGrid(g, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+
+        rng = MersenneTwister(20260419)
+        pts = [SVector{3,Float64}(rand(rng), rand(rng), rand(rng)) for _ in 1:100]
+
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "4D grid exercises deeper recursion" begin
+        g((x,y,z,w)) = exp(-(x^2 + y^2 + z^2 + w^2))
+        fun = AdaptiveSparseGrid(g, [-1.0, -1.0, -1.0, -1.0],
+                                  [1.0, 1.0, 1.0, 1.0],
+                                  tol=1e-2, max_depth=9)
+
+        rng = MersenneTwister(20260419)
+        pts = [(-1 + 2*rand(rng), -1 + 2*rand(rng),
+                -1 + 2*rand(rng), -1 + 2*rand(rng)) for _ in 1:120]
+
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "Query at node coordinates (boundary xd == nxd)" begin
+        # The batched partition uses `xd < nxd` / `xd > nxd` strict comparisons,
+        # so points with `xd == nxd` along some dimension are dropped from that
+        # dimension's child subsets. This must agree with per-point `childsplit`,
+        # which also returns 0 on equality. Random test points never hit this;
+        # we construct points that land exactly on grid node coordinates.
+        g((x,y)) = exp(-(x^2 + y^2))
+        fun = AdaptiveSparseGrid(g, [0.0, 0.0], [1.0, 1.0],
+                                 tol=1e-4, max_depth=10)
+
+        pts = [
+            (0.5, 0.5),    # root coordinate
+            (0.5, 0.25),   # exactly on a dim-1 node line
+            (0.25, 0.5),   # exactly on a dim-2 node line
+            (0.5, 0.75),
+            (0.75, 0.5),
+            (0.125, 0.5),
+            (0.5, 0.125),
+        ]
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "Repeated-call stability" begin
+        # Evaluate twice with no intervening work. Catches scratch-buffer
+        # leakage or any state carried between calls.
+        g((x,y,z)) = sin(x) * cos(y) + z
+        fun = AdaptiveSparseGrid(g, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+
+        rng = MersenneTwister(20260419)
+        pts = [(rand(rng), rand(rng), rand(rng)) for _ in 1:200]
+
+        ys1 = zeros(length(pts)); evaluate!(ys1, fun, pts)
+        ys2 = zeros(length(pts)); evaluate!(ys2, fun, pts)
+        @test ys1 == ys2
+    end
+
+    @testset "Input validation" begin
+        g((x,y)) = x + y
+        fun = AdaptiveSparseGrid(g, [0.0, 0.0], [1.0, 1.0],
+                                 tol=1e-2, max_depth=6)
+        pts = [(0.1, 0.2), (0.3, 0.4), (0.5, 0.6)]
+
+        # Length mismatch should raise DimensionMismatch.
+        @test_throws DimensionMismatch evaluate!(zeros(2), fun, pts)
+        @test_throws DimensionMismatch evaluate!(zeros(5), fun, pts)
+
+        # Empty input must be a no-op (M == 0 early return).
+        ys_empty = Float64[]
+        evaluate!(ys_empty, fun, typeof(pts)())
+        @test isempty(ys_empty)
+    end
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using AdaptiveSparseGrids
 using ForwardDiff
 using StaticArrays
 using QuadGK
+using Random
 
 @testset "Adaptive Sparse Grid Tests" begin
 
@@ -333,6 +334,98 @@ end
             @test abs(f(x) - g(x))/max(g(x),1) < 1e-8
         end
     end
+
+@testset "Bulk evaluate! matches per-point" begin
+    import AdaptiveSparseGrids: evaluate!
+    # Regression tests: _bulk_evaluate! (including the batched K=1 path) must
+    # return the exact same values as per-point evaluation for every input.
+    # Before the fix, the scalar-codomain batched walk threaded a single shared
+    # `saved` scratch vector through recursion; child frames clobbered the
+    # parent's snapshot of `wrk`, corrupting sibling descents and producing
+    # garbage for most points.
+
+    rtol = 1e-12
+
+    @testset "2D scalar (gauss)" begin
+        gauss((x,y)) = exp(-(x^2 + y^2))
+        fun = AdaptiveSparseGrid(gauss, [-1.0, -1.0], [1.0, 1.0],
+                                 tol=1e-4, max_depth=12)
+
+        rng = MersenneTwister(20260419)
+        pts = [(-1 + 2*rand(rng), -1 + 2*rand(rng)) for _ in 1:200]
+
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test length(ys) == length(expected)
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "3D scalar (gauss)" begin
+        gauss((x,y,z)) = exp(-(x^2 + y^2 + z^2))
+        fun = AdaptiveSparseGrid(gauss, [-1.0, -1.0, -1.0], [1.0, 1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+
+        rng = MersenneTwister(20260419)
+        pts = [(-1 + 2*rand(rng), -1 + 2*rand(rng), -1 + 2*rand(rng))
+               for _ in 1:200]
+
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "Vector-of-Vector input" begin
+        # Point type matters: the dispatch accepts AbstractVector or Tuple.
+        g((x,y,z)) = sin(x) * cos(y) + z^2
+        fun = AdaptiveSparseGrid(g, [0.0, 0.0, 0.0], [1.0, 1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+
+        rng = MersenneTwister(20260419)
+        pts = [[rand(rng), rand(rng), rand(rng)] for _ in 1:150]
+
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "Small batch (M < nthreads) still correct" begin
+        # Thread chunking: cld(M, nth) with M smaller than nth forces some
+        # chunks empty. Make sure edge cases don't break correctness.
+        g((x,y)) = exp(-(x^2 + y^2))
+        fun = AdaptiveSparseGrid(g, [-1.0, -1.0], [1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+
+        pts = [(0.1, 0.2), (0.3, -0.4), (-0.5, 0.6)]
+        expected = [fun(p) for p in pts]
+        ys       = zeros(length(pts))
+        evaluate!(ys, fun, pts)
+
+        @test maximum(abs, ys .- expected) < rtol
+    end
+
+    @testset "Multi-codomain matches per-point" begin
+        # K > 1 uses the point-parallel fallback path but should still agree
+        # with per-point evaluation.
+        g((x,y)) = (a = sin(x)*cos(y), b = x^2 + y^2)
+        fun = AdaptiveSparseGrid(g, [0.0, 0.0], [1.0, 1.0],
+                                 tol=1e-3, max_depth=10)
+
+        rng = MersenneTwister(20260419)
+        pts = [(rand(rng), rand(rng)) for _ in 1:100]
+
+        expected = [fun(p) for p in pts]
+        ys       = similar(expected)
+        evaluate!(ys, fun, pts)
+
+        @test all(ys[i] == expected[i] for i in eachindex(pts))
+    end
+end
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -558,6 +558,38 @@ end
     end
 end
 
+@testset "sync_eval! invariants" begin
+    # Flat-eval view invariants. End-to-end correctness tests would catch
+    # any desync via wrong values, but direct assertions make regressions
+    # easier to diagnose.
+    import AdaptiveSparseGrids: base
+
+    g((x,y)) = sin(x) * cos(y)
+    fun = AdaptiveSparseGrid(g, [0.0, 0.0], [π, π],
+                             tol=1e-3, max_depth=10)
+
+    # length(_eval) == length(nodes), every Node index has a slot.
+    @test length(fun._eval) == length(fun.nodes)
+    @test all(haskey(fun._id, idx) for idx in keys(fun.nodes))
+    @test all(1 <= fun._id[idx] <= length(fun._eval) for idx in keys(fun.nodes))
+
+    # Slot 1 is the root.
+    root_idx = base(fun)
+    @test fun._id[root_idx] == Int32(1)
+    @test fun._eval[1].α == fun.nodes[root_idx].α
+    @test fun._eval[1].x == fun.nodes[root_idx].x
+
+    # Spot-check a sample of non-root nodes: their EvalNode mirrors the Node.
+    for idx in Iterators.take(keys(fun.nodes), 20)
+        ev = fun._eval[fun._id[idx]]
+        n  = fun.nodes[idx]
+        @test ev.α == n.α
+        @test ev.x == n.x
+        @test ev.l == n.l
+        @test ev.i == n.i
+    end
+end
+
 @testset "Partial Integration (multi-D)" begin
     # 1D `AdaptiveIntegral` has `dims == {1}`, so in `integrate_recursive!`
     # every dim is an integration dim (`dd = true`) and the `!dd` branch


### PR DESCRIPTION
## Summary

Non-breaking internal refactors to `AdaptiveSparseGrids.jl`. Public API and existing test file are unchanged (81643/81643 pass at every commit — new bulk-eval regression tests added in the latest commit). Same-machine (Apple Silicon, Julia 1.12.5) serial eval is **7–21× faster** after this PR; bulk parallel eval (`evaluate!(ys, fun, xs)` at 8 threads) is **~35–80× faster** end-to-end than pre-PR serial, and **4–9× faster** than the post-PR single-threaded bulk path.

Also fixes broken CI (deprecated `actions/cache@v1` was auto-failing all runs) and a brittle derivative test.

> **Correction (cf8f134).** An earlier revision of this PR claimed **200–600×** bulk parallel speedups. A code-review pass caught that the scalar-codomain batched traversal was returning wrong values: two aliasing bugs in the per-thread scratch buffers (`saved` + `right_buf`) corrupted sibling subtrees, causing the traversal to short-circuit most of the work. The inflated numbers reflected skipped work, not a real win. Bugs are fixed, correctness tests added, and the bulk numbers below are the real ones.

## Headline numbers (same-machine, pre-PR vs now)

Single-point eval (serial):

| workload | nodes | **pre-PR** | **now** | speedup |
|----------|------:|-----------:|--------:|--------:|
| gauss 3D | 1073 | 5.12 µs | 0.48 µs | **10.7×** |
| gauss 4D | 2929 | 12.22 µs | 1.52 µs | **8.0×** |
| runge 4D | 3569 | 13.36 µs | 1.58 µs | **8.5×** |
| gauss 5D | 6993 | 94.36 µs | 4.12 µs | **22.9×** |

Bulk throughput (`for x in xs; fun(x); end` serial vs `evaluate!(ys, fun, xs)` at 8 threads, corrected post-fix):

| workload | **pre-PR serial** | **now serial** | **now 8T batched** | par/ser | end-to-end |
|----------|-----------:|-----------:|---------------:|--------:|-----------:|
| gauss 3D | 0.17 Mcalls/s | 1.46 | 5.95 | 4.1× | **35×** |
| gauss 4D | 0.04 | 0.37 | 3.14 | 8.5× | **78×** |
| runge 4D | 0.04 | 0.33 | 1.85 | 5.6× | **46×** |
| gauss 5D | 0.01 | 0.16 | 0.81 | 5.1× | **81×** |

The higher-D serial wins are larger because the old traversal paid 2N \`haskey\` probes per visited node. The bulk-parallel lift over bulk-serial is a more modest 4–9× on 8 threads — the batched traversal shares each node load across the whole point cloud in a thread-chunk, so it wins when the tree is deep relative to the point count, but there's real per-node scratch maintenance (push/pop on the \`saved\` stack, subset copies for sibling isolation) that eats into the single-threaded gain.

## What's in the PR

Each commit is green + bench-measured. Commit messages carry same-machine before/after numbers.

1. **Fix CI + \`Dϕ\` boundary test** — \`actions/cache@v1\` was auto-failing; bumped action versions. The \`Dϕ\` test compared against ForwardDiff on \`LinRange(-1, 1, 5)\` which hits the \`abs\` kink at \`x = 0\`; restricted to interior points.
2. **\`bench/benchmarks.jl\`** — full benchmark suite.
3. **\`bench/compare.jl\`** — small deterministic per-commit tracker; output is pasted into every perf commit for traceability.
4. **Phase 1 — pre-linked children** *(single biggest serial win)*. Drops the per-visit \`Dict{Index,Node}\` lookup + \`2N\` \`haskey\` probes from \`evaluate_recursive\` / \`integrate_recursive!\`. \`Node\` gains \`left::NTuple{D,Union{Nothing,Node}}\` / \`right::NTuple{D,...}\`, populated by \`link_to_parents!\` inside \`drive_to_college!\`. Dict stays around for fit-time parent lookups.
5. **Phase 6a cleanups** — drop unused \`inclusive\` kwarg on \`childsplit\`.
6. **Phase 5 — threaded bulk eval API**. New \`evaluate!(ys, fun, xs)\` with \`Threads.@threads\`. Element type on \`xs\` constrained to \`AbstractVector\`/\`Tuple\` so the new method doesn't shadow the existing single-point \`evaluate!(y, fun, x)\` when \`x\` is a plain vector.
7. **\`@inbounds\`** on hot \`for d in 1:D\` loops (D is a type parameter; tuple indexing is provably safe).
8. **Phase 7 — hot-first Node field order** (α, x, l, left, right | fx, i, depth).
9. **Phase 8 — flat \`Vector{EvalNode}\` + \`Int32\` child indices** *(second biggest serial win)*. New \`struct EvalNode{D,K,T}\` — immutable, bitstype — holding just the eval hot set. \`AdaptiveSparseGrid\` gets \`_eval::Vector{EvalNode}\` (slot 1 = root) and \`_id::Dict{Index,Int32}\`, kept in sync by \`sync_eval!\` after every \`drive_to_college!\` and after the initial \`train!([root])\` in \`fit!\`. Eval walks the flat array; children are integer offsets with \`0\` as a "no child" sentinel. Cuts the per-node hot footprint roughly in half and makes the visited set L1-resident for moderate grids.
10. **Phase 9 — batch-coherent bulk eval (K = 1)**. \`_bulk_evaluate_batched!\` walks the tree once per thread-chunk, carrying a subset of active point indices at each node and partitioning by \`childsplit\` into left/right sub-subsets. Each node is loaded a constant number of times per thread instead of once per point. Multi-codomain (K > 1) still dispatches to per-point parallel.
11. **README** — new "Evaluating many points at once" section pointing users at \`evaluate!(ys, fun, xs)\`.
12. **Phase 11 — LLVM-level cleanup** to \`evaluate_recursive\` hot path (removed GC frame from string-interpolated throws in \`m\`/\`ϕ\`/\`I\`).
13. **Fix: correctness bugs in \`_batch_recurse!\`** — two aliasing bugs in the shared scratch buffers used by the K=1 batch traversal:
    - \`saved::Vector{Float64}\`: was \`resize!\`d per-frame, so child frames clobbered the parent's snapshot of \`wrk[dimshift, ·]\`. Fix: use as a push/pop stack.
    - \`right_buf::Vector{Int32}\`: populated by the parent, then clobbered by the left child's own recursion (which reuses the same buffer). Parent then fed garbage indices to the right child. Fix: when both children exist, snapshot both \`left_buf\` and \`right_buf\` before either recursion.
    Adds \`@testset "Bulk evaluate! matches per-point"\` covering 2D/3D scalar (Tuple and Vector point types), small-batch (M < nthreads), and multi-codomain fallback. All RED pre-fix, GREEN post-fix.

## What was tried and reverted or skipped

- **Precomputed per-node basis coefficients** (unified \`max(0, 1 - |a·x + b|)\` form) — measured flat. **Reverted.**
- **K = 1 scalar specialization** — confirmed already routed through scalar-k accumulator path. **Skipped.**
- **Nodal basis transform** — for adaptive (not pure Smolyak) grids, no interpretation obviously wins. **Skipped by design.**

## Test plan

- [x] \`Pkg.test("AdaptiveSparseGrids")\` — 81643/81643 (includes new bulk-eval regression tests).
- [x] \`julia --project=bench bench/compare.jl\` under \`-t 8\` — numbers above.
- [ ] CI green on re-run.